### PR TITLE
Start the engine before the phone has been unlocked

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,9 +8,12 @@
 		android:supportsRtl="true"
 		android:theme="@style/Theme.Evvdroid">
 
+		<!-- Startable on the lock screen, which is where a screen reader is
+		     wanted first. What it reads there is in DirectBoot.kt. -->
 		<service
 			android:name=".EvvTtsService"
 			android:label="@string/engine_name"
+			android:directBootAware="true"
 			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.TTS_SERVICE" />

--- a/app/src/main/kotlin/org/evvdroid/DirectBoot.kt
+++ b/app/src/main/kotlin/org/evvdroid/DirectBoot.kt
@@ -1,0 +1,100 @@
+package org.evvdroid
+
+import android.content.Context
+import android.os.Build
+import android.os.UserManager
+import android.util.Log
+import java.io.File
+
+/**
+ * Where the engine keeps what it needs before the phone has been unlocked.
+ *
+ * A screen reader is the first thing wanted on a locked phone and the last
+ * thing that can wait for a PIN, so the speech service is marked direct-boot
+ * aware and starts while the user's own storage is still encrypted. Ordinary
+ * app storage is not there yet at that point: reading it throws, and settings
+ * read through it would come back as the defaults, so the voice would be the
+ * wrong one until somebody unlocked the phone and restarted the engine.
+ *
+ * Device-protected storage is readable from the moment the phone boots, and is
+ * what everything the engine reads at startup lives in. It is a different
+ * directory rather than a different kind of file, so what is stored there is
+ * moved once, the first time a build with this in it runs after an unlock.
+ */
+object DirectBoot {
+
+	/** The context to read settings and the files they name through. */
+	fun storage(context: Context): Context {
+		val app = context.applicationContext
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return app
+		val device = app.createDeviceProtectedStorageContext() ?: return app
+		// Both of these are no-ops once there is nothing left behind to bring
+		// over, which is every run after the first.
+		device.moveSharedPreferencesFrom(app, prefsName(app))
+		bringDictionariesForward(app, device)
+		return device
+	}
+
+	/** The dictionaries directory, wherever it is being kept. */
+	fun dictionaries(context: Context): File =
+		File(storage(context).filesDir, DICTIONARIES)
+
+	private fun prefsName(app: Context) = "${app.packageName}_preferences"
+
+	/**
+	 * Moves dictionaries picked by an earlier build into device-protected
+	 * storage and points the settings at where they went.
+	 *
+	 * Nothing can be moved while the phone is locked -- the directory being
+	 * moved from is the one that is not readable yet -- so a locked start
+	 * leaves this for the next unlocked one. Until then the service finds the
+	 * files missing and speaks without them, which is what it already does for
+	 * a dictionary that has been deleted.
+	 */
+	private fun bringDictionariesForward(app: Context, device: Context) {
+		if (!isUnlocked(app)) return
+		val from = File(app.filesDir, DICTIONARIES)
+		if (!from.isDirectory) return
+		val into = File(device.filesDir, DICTIONARIES)
+		val moved = mutableMapOf<String, String>()
+		for (file in from.listFiles().orEmpty()) {
+			if (!file.isFile) continue
+			if (!into.isDirectory && !into.mkdirs()) return
+			val there = File(into, file.name)
+			try {
+				// The two are on different mounts, so a rename can refuse and
+				// the copy is not a fallback for a rare case but the usual way.
+				if (!file.renameTo(there)) {
+					file.copyTo(there, overwrite = true)
+					file.delete()
+				}
+			} catch (stuck: Exception) {
+				// Left where it is, and left in the settings as where it is,
+				// so the next unlocked start tries again.
+				Log.e(TAG, "cannot move ${file.name} to device-protected storage", stuck)
+				continue
+			}
+			moved[file.absolutePath] = there.absolutePath
+		}
+		from.delete()
+		if (moved.isEmpty()) return
+		val prefs = device.getSharedPreferences(prefsName(app), Context.MODE_PRIVATE)
+		val edit = prefs.edit()
+		for (volume in Eci.DICT_VOLUMES) {
+			val key = Settings.dictionaryPathKey(volume)
+			val was = prefs.getString(key, null) ?: continue
+			moved[was]?.let { edit.putString(key, it) }
+		}
+		edit.apply()
+	}
+
+	private fun isUnlocked(app: Context): Boolean {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return true
+		val users = app.getSystemService(UserManager::class.java) ?: return true
+		return users.isUserUnlocked
+	}
+
+	private const val DICTIONARIES = "dictionaries"
+
+	private const val TAG = "evvdroid"
+}

--- a/app/src/main/kotlin/org/evvdroid/EvvTtsService.kt
+++ b/app/src/main/kotlin/org/evvdroid/EvvTtsService.kt
@@ -157,12 +157,15 @@ class EvvTtsService : TextToSpeechService() {
 	/** Teaching three thousand words costs about half a second, so it happens
 	 *  when the files change rather than whenever any setting does. */
 	private fun loadDictionaries(target: EvvEngine, s: Settings) {
-		val want = s.dictionaryPaths()
+		// What is there rather than what was asked for. A dictionary picked
+		// before this build is not where the settings say until the phone has
+		// been unlocked once, and remembering only what was read means it is
+		// picked up when it arrives instead of being written off as loaded.
+		val want = s.dictionaryPaths().filterValues { java.io.File(it).exists() }
 		if (want == loadedDictionaries) return
 		target.forgetDictionaries()
 		for ((volume, path) in want) {
 			val file = java.io.File(path)
-			if (!file.exists()) continue
 			val taught = Dictionaries.load(target, volume, file)
 			Log.i(TAG, "volume $volume: $taught entries from ${file.name}")
 		}

--- a/app/src/main/kotlin/org/evvdroid/Settings.kt
+++ b/app/src/main/kotlin/org/evvdroid/Settings.kt
@@ -24,8 +24,10 @@ import android.content.SharedPreferences
 class Settings(context: Context) {
 
 	// The file androidx.preference used, kept under that name so a build with
-	// the old screen and a build with this one read the same settings.
-	private val prefs: SharedPreferences = context.applicationContext
+	// the old screen and a build with this one read the same settings. It is
+	// read through device-protected storage, because the speech service reads
+	// it while the phone is still locked. DirectBoot has the rest of that.
+	private val prefs: SharedPreferences = DirectBoot.storage(context)
 		.getSharedPreferences("${context.packageName}_preferences", Context.MODE_PRIVATE)
 
 	@Volatile
@@ -142,16 +144,16 @@ class Settings(context: Context) {
 
 	// ---- dictionaries ----------------------------------------------------
 
-	fun dictionaryPath(volume: Int): String? = prefs.getString("dict_path_$volume", null)
+	fun dictionaryPath(volume: Int): String? = prefs.getString(dictionaryPathKey(volume), null)
 
 	fun dictionaryName(volume: Int): String? = prefs.getString("dict_name_$volume", null)
 
 	fun setDictionary(volume: Int, path: String?, name: String?) {
 		val edit = prefs.edit()
 		if (path == null) {
-			edit.remove("dict_path_$volume").remove("dict_name_$volume")
+			edit.remove(dictionaryPathKey(volume)).remove("dict_name_$volume")
 		} else {
-			edit.putString("dict_path_$volume", path).putString("dict_name_$volume", name)
+			edit.putString(dictionaryPathKey(volume), path).putString("dict_name_$volume", name)
 		}
 		edit.apply()
 	}
@@ -170,6 +172,10 @@ class Settings(context: Context) {
 		const val KEY_PAUSES = "pauses"
 		const val KEY_PHRASE_PREDICTION = "phrase_prediction"
 		const val DEFAULT_SAMPLE_RATE = 11025
+
+		/** Where the copy taken of a picked dictionary is recorded. DirectBoot
+		 *  rewrites these when it moves the files, so it needs the name too. */
+		fun dictionaryPathKey(volume: Int) = "dict_path_$volume"
 
 		/** The eight, in the order the settings screen shows them. */
 		val SHAPE = listOf(

--- a/app/src/main/kotlin/org/evvdroid/SettingsModel.kt
+++ b/app/src/main/kotlin/org/evvdroid/SettingsModel.kt
@@ -109,10 +109,12 @@ class SettingsModel(context: Context) {
 	 * A picked document is a content URI belonging to whichever app supplied
 	 * it, readable now and quite possibly not tomorrow, and the speech service
 	 * is a different process that reads these when it starts. So what is stored
-	 * is a copy of our own rather than a reference to somebody else's.
+	 * is a copy of our own rather than a reference to somebody else's, kept in
+	 * device-protected storage so that the service can still read it during a
+	 * locked boot.
 	 */
 	fun chooseDictionary(volume: Int, uri: android.net.Uri) {
-		val into = java.io.File(app.filesDir, "dictionaries").apply { mkdirs() }
+		val into = DirectBoot.dictionaries(app).apply { mkdirs() }
 		val file = java.io.File(into, "volume-$volume.dic")
 		val name = nameOf(uri) ?: file.name
 		try {


### PR DESCRIPTION
The engine is not startable until the phone has been unlocked, so a screen
reader has no voice on the lock screen and none during the whole of a locked
boot. This marks the speech service direct-boot aware and moves what it reads
at startup into device-protected storage.

- `EvvTtsService` is `android:directBootAware="true"`. Nothing else is: the
  settings screen has no business running before an unlock.
- `DirectBoot` hands out the device-protected context. Ordinary app storage is
  not readable that early, and settings read through it would come back as the
  defaults, so the voice would be the wrong one until somebody unlocked the
  phone and the engine restarted.
- Settings already written are carried over once by `moveSharedPreferencesFrom`,
  and dictionaries picked by an earlier build are moved across with them, with
  the paths recorded for them rewritten to where they went. The two are on
  different mounts, so a rename usually refuses and the copy is the normal
  path. Nothing can be moved while the phone is locked -- the directory being
  moved from is the one that is not readable yet -- so a locked start leaves it
  for the next unlocked one.
- `loadDictionaries` compares against the files that are actually there rather
  than the paths asked for. Without that, a locked start with a dictionary that
  has not been moved yet would record it as loaded and never pick it up.

Tested on a device running Android 16. The system reports the service as
`directBootAware=true` and the package as `PARTIALLY_DIRECT_BOOT_AWARE`, and
settings written by the previous build came across intact: the preferences file
is now under `/data/user_de/0/org.evvdroid/shared_prefs` with every value that
was in it, and the credential-protected copy is gone.

It has been through a real locked boot as well: with a screen lock set, the
phone was rebooted and the engine spoke before it was unlocked.

The dictionary move is the one part that has been reasoned through rather than
watched -- no dictionary was picked on the device it was tried on.

