### PR TITLE
fix the pitch and rate sticking after an interruption

### DIFF
--- a/app/src/androidTest/kotlin/org/evvdroid/EngineTest.kt
+++ b/app/src/androidTest/kotlin/org/evvdroid/EngineTest.kt
@@ -199,11 +199,19 @@ class EngineTest {
 		)
 	}
 
-	/** Android's speech rate and pitch are percentages of normal, and normal is
-	 *  the voice as it stands. A hundred per cent has to change nothing. */
+	/**
+	 * Android's speech rate and pitch are percentages of normal, and normal is
+	 * the voice as it stands. A hundred per cent has to change nothing.
+	 *
+	 * The doubled rate is heard rather than read back out of the voice, because
+	 * neither goes into the voice any more: both are sent in front of the words
+	 * for the reason Prosody gives. So the voice standing still under an ask is
+	 * part of what this says now rather than something it works around.
+	 */
 	@Test
 	fun aRateOfOneHundredPerCentChangesNothing() {
 		val e = open()
+		e.setSampleRate(11025)
 		e.applyVoice(0)
 		val speed = e.getVoiceParam(Eci.VOICE_SPEED)
 		val pitch = e.getVoiceParam(Eci.VOICE_PITCH_BASELINE)
@@ -211,8 +219,10 @@ class EngineTest {
 		e.setPitchPercent(100)
 		assertEquals("the speed moved", speed, e.getVoiceParam(Eci.VOICE_SPEED))
 		assertEquals("the pitch moved", pitch, e.getVoiceParam(Eci.VOICE_PITCH_BASELINE))
+		val ordinary = collect(e, SENTENCE).size
 		e.setRatePercent(200)
-		assertTrue("a doubled rate did nothing", e.getVoiceParam(Eci.VOICE_SPEED) > speed)
+		val quicker = collect(e, SENTENCE).size
+		assertTrue("a doubled rate did nothing: $quicker against $ordinary", quicker < ordinary)
 	}
 
 	/** A Latin-1 character is in the engine's own code set and goes straight

--- a/app/src/androidTest/kotlin/org/evvdroid/ProsodyTest.kt
+++ b/app/src/androidTest/kotlin/org/evvdroid/ProsodyTest.kt
@@ -7,8 +7,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
-/** Phrase prediction, which is an annotation rather than a parameter, so the
- *  only way to know the engine took it is to listen to the difference. */
+/** What is asked of the engine by annotation rather than by parameter, so the
+ *  only way to know it took is to listen to the difference. */
 @RunWith(AndroidJUnit4::class)
 class ProsodyTest {
 
@@ -38,6 +38,53 @@ class ProsodyTest {
 		}
 	}
 
+	/**
+	 * A rate asked for while the engine is still speaking.
+	 *
+	 * This is where a screen reader asks: every item cuts off the one before,
+	 * so the ask lands while the last utterance is still being made. The
+	 * engine refuses a written parameter then -- vc_reentered answers -1 while
+	 * the instance is busy -- and says so only in a return value, so an ask
+	 * made at that moment used to be dropped, and the voice went on at
+	 * whatever the last utterance left it until something happened to ask for
+	 * a different number.
+	 */
+	@Test
+	fun aRateAskedForWhileTheEngineIsSpeakingIsStillHeard() {
+		val e = EvvEngine.open(ENGLISH)
+		assertNotNull(e)
+		try {
+			e!!.setSampleRate(11025)
+			e.applyVoice(0)
+			e.setRatePercent(100)
+			val quick = say(e, SENTENCE)
+			// Half speed with nothing in the way, to know what it sounds like
+			// when it does land.
+			e.setRatePercent(50)
+			val slow = say(e, SENTENCE)
+			assertTrue("half speed was no slower: $slow against $quick", slow > quick)
+
+			// And now the same ask, made in the middle of an utterance.
+			e.setRatePercent(100)
+			say(e, SENTENCE)
+			assertTrue("nothing was queued", e.speak(PARAGRAPH))
+			val buffer = ByteArray(4096)
+			// One read, so the engine is certainly running by the time the ask
+			// is made rather than merely holding the text.
+			e.read(buffer)
+			e.setRatePercent(50)
+			e.stop()
+			while (e.read(buffer) > 0) Unit
+			val after = say(e, SENTENCE)
+			assertTrue(
+				"the rate asked for mid-utterance was never heard: $after against $quick",
+				after > quick + quick / 5
+			)
+		} finally {
+			e?.close()
+		}
+	}
+
 	private fun say(e: EvvEngine, text: String): Int {
 		if (!e.speak(text)) return -1
 		var total = 0
@@ -53,5 +100,8 @@ class ProsodyTest {
 	private companion object {
 		const val ENGLISH = 0x00010000
 		const val SENTENCE = "The header is read first, and the list that follows it is long."
+		val PARAGRAPH = ("The quick brown fox jumps over the lazy dog. " +
+			"Every good boy deserves favour, and the rain in Spain stays mainly in the plain. ")
+			.repeat(6)
 	}
 }

--- a/app/src/main/kotlin/org/evvdroid/EvvEngine.kt
+++ b/app/src/main/kotlin/org/evvdroid/EvvEngine.kt
@@ -24,8 +24,11 @@ class EvvEngine private constructor(private var handle: Long, val language: Int)
 	private var baseSpeed = -1
 	private var basePitch = -1
 
-	private var currentRate = -1
-	private var currentPitch = -1
+	/** What the rate and pitch last asked for come to in the engine's own
+	 *  numbers, sent in front of every utterance. Below nought until a voice
+	 *  has been applied, when there is no base to scale them onto. */
+	private var wantSpeed = -1
+	private var wantPitch = -1
 
 	companion object {
 		private const val TAG = "evvdroid"
@@ -109,43 +112,52 @@ class EvvEngine private constructor(private var handle: Long, val language: Int)
 	 * preset had, which is why an empty map is the right thing to pass when
 	 * nobody has chosen otherwise.
 	 */
-	fun applyVoice(index: Int, shape: Map<Int, Int> = emptyMap()) = synchronized(guard) {
-		if (closed) return
+	fun applyVoice(index: Int, shape: Map<Int, Int> = emptyMap()): Boolean = synchronized(guard) {
+		if (closed) return false
 		val preset = (index + Eci.FIRST_PRESET).coerceIn(Eci.FIRST_PRESET, Eci.LAST_PRESET)
-		EvvNative.copyVoice(handle, preset, Eci.SCRATCH_VOICE)
+		// A voice is written rather than annotated, so it can be refused: the
+		// engine takes nothing while it is speaking, and answers nought for a
+		// copy and -1 for a parameter when it does. Saying so is what lets the
+		// caller ask again rather than believe a voice is in force that never
+		// arrived.
+		if (EvvNative.copyVoice(handle, preset, Eci.SCRATCH_VOICE) == 0) return false
 		// The preset's own speed is not kept. Two of the eight ship faster than
 		// the rest, so leaving it would make changing voice change the pace.
-		EvvNative.setVoiceParam(
-			handle, Eci.SCRATCH_VOICE, Eci.VOICE_SPEED,
-			shape[Eci.VOICE_SPEED] ?: Eci.DEFAULT_SPEED
-		)
+		if (EvvNative.setVoiceParam(
+				handle, Eci.SCRATCH_VOICE, Eci.VOICE_SPEED,
+				shape[Eci.VOICE_SPEED] ?: Eci.DEFAULT_SPEED
+			) < 0
+		) return false
 		for ((param, value) in shape) {
-			EvvNative.setVoiceParam(handle, Eci.SCRATCH_VOICE, param, Eci.clampVoice(param, value))
+			if (EvvNative.setVoiceParam(
+					handle, Eci.SCRATCH_VOICE, param, Eci.clampVoice(param, value)
+				) < 0
+			) return false
 		}
-		EvvNative.copyVoice(handle, Eci.SCRATCH_VOICE, Eci.VOICE_CURRENT)
+		if (EvvNative.copyVoice(handle, Eci.SCRATCH_VOICE, Eci.VOICE_CURRENT) == 0) return false
+		// Reading is never refused, only writing, so these are what the engine
+		// really has.
 		baseSpeed = EvvNative.getVoiceParam(handle, Eci.VOICE_CURRENT, Eci.VOICE_SPEED)
 		basePitch = EvvNative.getVoiceParam(handle, Eci.VOICE_CURRENT, Eci.VOICE_PITCH_BASELINE)
-		currentRate = -1
-		currentPitch = -1
+		wantSpeed = baseSpeed
+		wantPitch = basePitch
+		return true
 	}
 
 	/** Android hands rate and pitch over as a percentage of normal, where the
 	 *  engine wants its own numbers. Normal is the voice as [applyVoice] left
-	 *  it, so 100% changes nothing. */
+	 *  it, so 100% changes nothing. Neither is written: [speak] sends both in
+	 *  front of the words, for the reason [Prosody] gives. */
 	fun setRatePercent(percent: Int) = synchronized(guard) {
-		if (closed || percent == currentRate || baseSpeed < 0) return
+		if (closed || baseSpeed < 0) return
 		// Not baseSpeed * percent. The engine's speed scale is nothing like
 		// linear in how fast it speaks, so SpeechRate does the conversion.
-		val want = SpeechRate.speedForPercent(baseSpeed, percent)
-		EvvNative.setVoiceParam(handle, Eci.VOICE_CURRENT, Eci.VOICE_SPEED, want)
-		currentRate = percent
+		wantSpeed = SpeechRate.speedForPercent(baseSpeed, percent)
 	}
 
 	fun setPitchPercent(percent: Int) = synchronized(guard) {
-		if (closed || percent == currentPitch || basePitch < 0) return
-		val want = (basePitch.toLong() * percent / 100).toInt().coerceIn(0, Eci.PERCENT_MAX)
-		EvvNative.setVoiceParam(handle, Eci.VOICE_CURRENT, Eci.VOICE_PITCH_BASELINE, want)
-		currentPitch = percent
+		if (closed || basePitch < 0) return
+		wantPitch = (basePitch.toLong() * percent / 100).toInt().coerceIn(0, Eci.PERCENT_MAX)
 	}
 
 	fun getVoiceParam(param: Int): Int = synchronized(guard) {
@@ -171,9 +183,14 @@ class EvvEngine private constructor(private var handle: Long, val language: Int)
 		if (!closed) EvvNative.forgetDictionaries(handle)
 	}
 
-	/** Queues [text] and starts the engine. The samples come out of [read]. */
+	/** Queues [text] and starts the engine. The samples come out of [read].
+	 *  The rate and pitch asked for go in front of the words rather than into
+	 *  the voice, so that an utterance carries its own and nothing is left to
+	 *  be refused. */
 	fun speak(text: String): Boolean = synchronized(guard) {
-		if (closed) false else EvvNative.speak(handle, WesternText.encode(text))
+		if (closed) return false
+		val ask = if (wantSpeed >= 0 && wantPitch >= 0) Prosody.voice(wantSpeed, wantPitch) else ""
+		return EvvNative.speak(handle, WesternText.encode(ask + text))
 	}
 
 	/** Bytes of PCM, blocking until there are some. 0 ends the utterance and

--- a/app/src/main/kotlin/org/evvdroid/EvvTtsService.kt
+++ b/app/src/main/kotlin/org/evvdroid/EvvTtsService.kt
@@ -150,8 +150,10 @@ class EvvTtsService : TextToSpeechService() {
 		target.setSampleRate(s.sampleRateHz)
 		target.setAbbreviations(s.abbreviations)
 		loadDictionaries(target, s)
-		target.applyVoice(s.voice, s.shape(s.voice))
-		appliedRevision = s.revision
+		// A voice is written, so the engine can refuse it while it is speaking.
+		// One that did not land is left unrecorded and asked for again at the
+		// next utterance rather than believed.
+		if (target.applyVoice(s.voice, s.shape(s.voice))) appliedRevision = s.revision
 	}
 
 	/** Teaching three thousand words costs about half a second, so it happens

--- a/app/src/main/kotlin/org/evvdroid/Prosody.kt
+++ b/app/src/main/kotlin/org/evvdroid/Prosody.kt
@@ -10,11 +10,27 @@ package org.evvdroid
  * the guess is wrong, so it is off unless asked for. There is no parameter for
  * it, only the annotation, which is why it is sent with every utterance rather
  * than set once.
+ *
+ * Rate and pitch have a parameter and are sent here anyway. The engine refuses
+ * a written parameter while it is speaking -- vc_reentered answers -1 for the
+ * whole time the instance is busy, which for this app is whenever the thread
+ * that runs the engine is inside eciSynchronize -- and a screen reader asks
+ * for exactly that moment, because every item it speaks cuts off the one
+ * before. An annotation travels in the text instead, through the same queue
+ * the synthesizer already reads in order, so it lands for the utterance that
+ * asked for it and nothing has to survive in between.
  */
 object Prosody {
 
 	/** What to put in front of one utterance. */
 	fun prefix(phrasePrediction: Boolean): String = if (phrasePrediction) ON else OFF
+
+	/** The rate and pitch to speak one utterance at, in the engine's own
+	 *  numbers. A malformed annotation is spoken aloud rather than obeyed, so
+	 *  both are clamped to what the engine will take. */
+	fun voice(speed: Int, pitch: Int): String =
+		"`vs${Eci.clampVoice(Eci.VOICE_SPEED, speed)} " +
+			"`vb${Eci.clampVoice(Eci.VOICE_PITCH_BASELINE, pitch)} "
 
 	private const val ON = "`pp1 "
 	private const val OFF = "`pp0 "


### PR DESCRIPTION
A pitch or rate asked for while the engine is speaking is dropped, and the
voice stays where the last utterance left it until something asks for a
different number. What it sounds like is the reader picking up another app's
pitch and keeping it a while.

`vc_reentered` in `src/eci/api/eci_voice.c` refuses every written parameter
while the instance is busy, so `eciSetVoiceParam` answers -1 and `eciCopyVoice`
answers nought and neither writes. That is the engine guarding the voice it is
rendering from, and a screen reader asks at exactly that moment, because every
item cuts off the one before. We threw the return value away and recorded the
percentage as applied regardless, so the next utterance asking for the same
percentage skipped the write. One refused write became a permanent one.

- Rate and pitch go in front of the words as `` `vs `` and `` `vb `` instead of
  into the voice. Annotations travel through the queue the synthesizer already
  reads in order, so they land for the utterance that asked. `setVoice` in
  `eci_state.c` does this internally, and the NVDA IBMTTS driver's "Always Send
  Current Speech Settings" does it for the same reason.
- The cached percentages go with them: there is no longer a write to skip.
- A voice still has to be written, so `applyVoice` answers whether it landed
  and `applySettings` records the revision only when it did.

`ProsodyTest.aRateAskedForWhileTheEngineIsSpeakingIsStillHeard` fails on the
current tree with `94600 against 94600` -- byte for byte the same audio, half
speed asked for mid-utterance having done nothing. 73 of 73 instrumented tests
pass here on an Android 16 device.

`EngineTest.aRateOfOneHundredPerCentChangesNothing` asserted the doubled rate by
reading the speed back out of the voice, which is the mechanism this removes, so
it now asserts it by listening instead. Worth a look: a test rewritten to suit a
change is how a regression hides.
